### PR TITLE
Corrected the composer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Installation
 --------
 
 ```bash
-$ composer require bakame/league-csv-doctrine-bridge
+$ composer require bakame/csv-doctrine-collection-bridge
 ```
 
 Usage


### PR DESCRIPTION
Fixed a small twist in the composer require command, because with the previous one it was impossible to install the package.

## Introduction
I've tried to install the package and failed several times because composer couldn't find the right version to install. After a while I found out on packagist that the composer command just had a little twist.

## Proposal

### Describe the new/updated/fixed feature
Just changed the composer command in the README.

### Backward Incompatible Changes
None relevant changes.

### Targeted release version
All versions.

### PR Impact
Making installation via composer possible.

## Open issues
No open issues.