### PR TITLE
Corrects typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $csv->setDelimiter(';');
 
 $criteria = Criteria::create()
     ->andWhere(Criteria::expr()->eq('prenom', 'Adam'))
-    ->orderBy(['annee', 'ASC'])
+    ->orderBy( [ 'annee' => 'ASC', 'foo' => 'desc', ] )
     ->setFirstResult(0)
     ->setMaxResults(10)
 ;


### PR DESCRIPTION
## Introduction
The `README` contains an example about Criteria ordering. Showen was a numerical array containing two items, while `Criteria::orderBy()` actually asks for an associative array of `column => ASC|DEC`. 

## Proposal

### Describe the new/updated/fixed feature

This PR fixes the example in the `README`.

### Backward Incompatible Changes

none

### Targeted release version

1.1.0

### PR Impact

none

## Open issues

none
